### PR TITLE
Add <cstdint> header to two external sources which require it.

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = meshlab
 	pkgdesc = System for processing and editing of unstructured 3D models arising in 3D scanning (qt5 version)
 	pkgver = 2022.02
-	pkgrel = 2
+	pkgrel = 3
 	url = https://www.meshlab.net
 	arch = i686
 	arch = x86_64
@@ -34,10 +34,12 @@ pkgbase = meshlab
 	optdepends = openctm-tools: for compressed triangle mesh file format
 	source = meshlab::git+https://github.com/cnr-isti-vclab/meshlab.git#tag=MeshLab-2022.02
 	source = vcglib::git+https://github.com/cnr-isti-vclab/vcglib.git#tag=2022.02
+	source = add_cstdint_header.patch
 	source = nexus::git+https://github.com/cnr-isti-vclab/nexus.git
 	source = corto::git+https://github.com/cnr-isti-vclab/corto.git
 	sha256sums = SKIP
 	sha256sums = SKIP
+	sha256sums = 3c31fd894778b60202be998262fb95c799194f8b246b7b44344243675a79c246
 	sha256sums = SKIP
 	sha256sums = SKIP
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,7 +14,7 @@
 pkgname=meshlab
 pkgver=2022.02
 _pkgver_vcg=${pkgver}
-pkgrel=2
+pkgrel=3
 pkgdesc="System for processing and editing of unstructured 3D models arising in 3D scanning (qt5 version)"
 arch=('i686' 'x86_64')
 url="https://www.meshlab.net"
@@ -30,14 +30,18 @@ optdepends=('u3d: for U3D and IDTF file support'
 #also create openctm(aur) jhead-lib structuresynth-lib to handle last dep
 source=("$pkgname::git+https://github.com/cnr-isti-vclab/meshlab.git#tag=MeshLab-${pkgver}"
         "vcglib::git+https://github.com/cnr-isti-vclab/vcglib.git#tag=${_pkgver_vcg}"
+        'add_cstdint_header.patch'
         )
 sha256sums=('SKIP'
             'SKIP'
+            '3c31fd894778b60202be998262fb95c799194f8b246b7b44344243675a79c246'
             'SKIP'
             'SKIP')
 
 prepare() {
   prepare_submodule
+  cd "${srcdir}/meshlab"
+  patch -p0 -i "$srcdir/add_cstdint_header.patch"
 }
 
 

--- a/add_cstdint_header.patch
+++ b/add_cstdint_header.patch
@@ -1,0 +1,25 @@
+--- src/external/nexus/src/corto/src/tunstall.cpp
++++ src/external/nexus/src/corto/src/tunstall.cpp
+
+@@ -19,7 +19,8 @@
+ #include <assert.h>
+ #include <math.h>
+ #include <string.h>
++#include <cstdint>
+ #include <deque>
+ #include <algorithm>
+ #include <iostream>
+ #include "tunstall.h"
+
+--- src/external/e57/include/E57Format.h
++++ src/external/e57/include/E57Format.h
+
+@@ -32,7 +32,8 @@
+ //! @file  E57Format.h header file for the E57 API
+ 
+ #include <cfloat>
++#include <cstdint>
+ #include <memory>
+ #include <vector>
+ 
+ #include "E57Exception.h"


### PR DESCRIPTION
Two files in the external (submodule) sources, `src/external/nexus/src/corto/src/tunstall.cpp` and `src/external/e57/include/E57Format.h` need to have `#include <cstdint>` added to compile. This pull requests adds a patch which is applied during `prepare()` *after* the submodules have been initialised to add these includes.